### PR TITLE
m2m speed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Python libraries for analysing OpenBadge data. See examples in the `examples rep
 
 Notes
 --------
-* When updaring the version, make the change in the master brnach (don't forget to git checkout master and git pull)
+* When updating the version, make the change in the master branch (don't forget to git checkout master and git pull)
 * Use bumpversion. For example "bumpversion patch" will increase the patch number
 * After updating the version, use "git push --tags"
 

--- a/openbadge_analysis/preprocessing/__init__.py
+++ b/openbadge_analysis/preprocessing/__init__.py
@@ -3,6 +3,7 @@
 from .raw import split_raw_data_by_day
 
 from .metadata import id_to_member_mapping
+from .metadata import legacy_id_to_member_mapping
 from .metadata import voltages
 from .metadata import sample_counts
 

--- a/openbadge_analysis/preprocessing/metadata.py
+++ b/openbadge_analysis/preprocessing/metadata.py
@@ -117,7 +117,7 @@ def id_to_member_mapping(mapper, time_bins_size='1min', tz='US/Eastern', fill_ga
         idmap = legacy_id_to_member_mapping(mapper, time_bins_size=time_bins_size, tz=tz, fill_gaps=fill_gaps)
         return idmap
     elif type(mapper) == pd.DataFrame:
-        idmap = {row.id: row.key for row in members_metadata.itertuples()}
+        idmap = {row.id: row.key for row in mapper.itertuples()}
         return pd.DataFrame.from_dict(idmap, orient='index')[0].rename('member')
     else:
         raise ValueError("You must provide either a fileobject or metadata dataframe as the mapper.")


### PR DESCRIPTION
Improves the speed of id_to_member_mapping and creation of member_to_member dataframe by assuming that ID's are uniquely mapped to keys and performing a join with the metadata, rather than a join with a full time series to match the entire m2m dataframe.

This should be fully backwards compatible, and checks types to determine if it should use the new method or the original one.